### PR TITLE
Fix compile issue around getting the epoch second from a DatePicker

### DIFF
--- a/src/main/scala/com/krystal/bull/gui/KrystalBullUtil.scala
+++ b/src/main/scala/com/krystal/bull/gui/KrystalBullUtil.scala
@@ -2,7 +2,7 @@ package com.krystal.bull.gui
 
 import scalafx.scene.control.DatePicker
 
-import java.time.{Instant, ZoneId}
+import java.time.{Instant, ZoneOffset}
 
 object KrystalBullUtil {
 
@@ -12,6 +12,6 @@ object KrystalBullUtil {
   def toInstant(datePicker: DatePicker): Instant = {
     //https://stackoverflow.com/a/23886207/967713
     val date: java.time.LocalDate = datePicker.delegate.getValue
-    date.atStartOfDay(ZoneId.systemDefault()).toInstant()
+    date.atStartOfDay(ZoneOffset.UTC).toInstant()
   }
 }

--- a/src/main/scala/com/krystal/bull/gui/KrystalBullUtil.scala
+++ b/src/main/scala/com/krystal/bull/gui/KrystalBullUtil.scala
@@ -1,0 +1,16 @@
+package com.krystal.bull.gui
+
+import scalafx.scene.control.DatePicker
+
+import java.time.Instant
+
+object KrystalBullUtil {
+
+  /** Converts a date picker into a Long that represents seconds
+    * since the epoch
+    */
+  def toInstant(datePicker: DatePicker): Instant = {
+    val date: java.time.LocalDate = datePicker.delegate.getValue
+    Instant.from(date)
+  }
+}

--- a/src/main/scala/com/krystal/bull/gui/KrystalBullUtil.scala
+++ b/src/main/scala/com/krystal/bull/gui/KrystalBullUtil.scala
@@ -2,7 +2,7 @@ package com.krystal.bull.gui
 
 import scalafx.scene.control.DatePicker
 
-import java.time.Instant
+import java.time.{Instant, ZoneId}
 
 object KrystalBullUtil {
 
@@ -10,7 +10,8 @@ object KrystalBullUtil {
     * since the epoch
     */
   def toInstant(datePicker: DatePicker): Instant = {
+    //https://stackoverflow.com/a/23886207/967713
     val date: java.time.LocalDate = datePicker.delegate.getValue
-    Instant.from(date)
+    date.atStartOfDay(ZoneId.systemDefault()).toInstant()
   }
 }

--- a/src/main/scala/com/krystal/bull/gui/dialog/CreateDigitDecompEventDialog.scala
+++ b/src/main/scala/com/krystal/bull/gui/dialog/CreateDigitDecompEventDialog.scala
@@ -1,8 +1,7 @@
 package com.krystal.bull.gui.dialog
 
 import java.time.{Instant, LocalTime, ZoneOffset}
-
-import com.krystal.bull.gui.{GUIUtil, GlobalData}
+import com.krystal.bull.gui.{GUIUtil, GlobalData, KrystalBullUtil}
 import com.krystal.bull.gui.home.InitEventParams
 import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.tlv.DigitDecompositionEventDescriptorV0TLV
@@ -25,7 +24,7 @@ object CreateDigitDecompEventDialog {
     dialog.resizable = true
 
     val eventNameTF = new TextField()
-    val datePicker = new DatePicker()
+    val datePicker: DatePicker = new DatePicker()
     val maxTF = new TextField()
     GUIUtil.setNumericInput(maxTF)
 
@@ -79,10 +78,7 @@ object CreateDigitDecompEventDialog {
       if (dialogButton == ButtonType.OK) {
         val eventName = eventNameTF.text.value
 
-        val maturityDateEpoch =
-          datePicker.value.value.toEpochSecond(LocalTime.MIN, ZoneOffset.UTC)
-
-        val maturityDate = Instant.ofEpochSecond(maturityDateEpoch)
+        val maturityDate = KrystalBullUtil.toInstant(datePicker)
 
         val maxNumber = maxTF.text.value.toLong
 

--- a/src/main/scala/com/krystal/bull/gui/dialog/CreateEnumEventDialog.scala
+++ b/src/main/scala/com/krystal/bull/gui/dialog/CreateEnumEventDialog.scala
@@ -1,8 +1,7 @@
 package com.krystal.bull.gui.dialog
 
 import java.time.{Instant, LocalTime, ZoneOffset}
-
-import com.krystal.bull.gui.GlobalData
+import com.krystal.bull.gui.{GlobalData, KrystalBullUtil}
 import com.krystal.bull.gui.home.InitEventParams
 import org.bitcoins.core.protocol.tlv.EnumEventDescriptorV0TLV
 import scalafx.Includes._
@@ -25,7 +24,7 @@ object CreateEnumEventDialog {
     dialog.resizable = true
 
     val eventNameTF = new TextField()
-    val datePicker = new DatePicker()
+    val datePicker: DatePicker = new DatePicker()
 
     val outcomeMap: scala.collection.mutable.Map[Int, TextField] =
       scala.collection.mutable.Map.empty
@@ -98,10 +97,7 @@ object CreateEnumEventDialog {
       if (dialogButton == ButtonType.OK) {
         val eventName = eventNameTF.text.value
 
-        val maturityDateEpoch =
-          datePicker.value.value.toEpochSecond(LocalTime.MIN, ZoneOffset.UTC)
-
-        val maturityDate = Instant.ofEpochSecond(maturityDateEpoch)
+        val maturityDate = KrystalBullUtil.toInstant(datePicker)
 
         val outcomeStrs = outcomeMap.values.toVector.distinct
         val outcomes = outcomeStrs.flatMap { keyStr =>

--- a/src/main/scala/com/krystal/bull/gui/dialog/CreateRangedEventDialog.scala
+++ b/src/main/scala/com/krystal/bull/gui/dialog/CreateRangedEventDialog.scala
@@ -1,9 +1,8 @@
 package com.krystal.bull.gui.dialog
 
 import java.time.{Instant, LocalTime, ZoneOffset}
-
 import com.krystal.bull.gui.home.InitEventParams
-import com.krystal.bull.gui.{GUIUtil, GlobalData}
+import com.krystal.bull.gui.{GUIUtil, GlobalData, KrystalBullUtil}
 import org.bitcoins.core.number._
 import org.bitcoins.core.protocol.tlv.RangeEventDescriptorV0TLV
 import scalafx.Includes._
@@ -84,10 +83,7 @@ object CreateRangedEventDialog {
       if (dialogButton == ButtonType.OK) {
         val eventName = eventNameTF.text.value
 
-        val maturityDateEpoch =
-          datePicker.value.value.toEpochSecond(LocalTime.MIN, ZoneOffset.UTC)
-
-        val maturityDate = Instant.ofEpochSecond(maturityDateEpoch)
+        val maturityDate = KrystalBullUtil.toInstant(datePicker)
 
         val start = startTF.text.value.toLong
         val step = stepTF.text.value.toLong


### PR DESCRIPTION
When running  cd9e1540a583232b7266fe208ffe5d9579495730 (latest master)  I get a compiler error 

```[info] compiling 18 Scala sources to /home/suredbits/dev/krystal-bull/target/scala-2.13/classes ...
[error] /home/suredbits/dev/krystal-bull/src/main/scala/com/krystal/bull/gui/dialog/CreateDigitDecompEventDialog.scala:83:34: value toEpochSecond is not a member of java.time.LocalDate
[error]           datePicker.value.value.toEpochSecond(LocalTime.MIN, ZoneOffset.UTC)
[error]                                  ^
[error] /home/suredbits/dev/krystal-bull/src/main/scala/com/krystal/bull/gui/dialog/CreateEnumEventDialog.scala:102:34: value toEpochSecond is not a member of java.time.LocalDate
[error]           datePicker.value.value.toEpochSecond(LocalTime.MIN, ZoneOffset.UTC)
[error]                                  ^
[error] /home/suredbits/dev/krystal-bull/src/main/scala/com/krystal/bull/gui/dialog/CreateRangedEventDialog.scala:88:34: value toEpochSecond is not a member of java.time.LocalDate
[error]           datePicker.value.value.toEpochSecond(LocalTime.MIN, ZoneOffset.UTC)
[error]                                  ^
[error] three errors found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 12 s, completed Dec 15, 2020 10:24:37 AM
[IJ]
```

This fixes these errors